### PR TITLE
A couple of proxy related fixes

### DIFF
--- a/Content/DriverAutomationTool.ps1
+++ b/Content/DriverAutomationTool.ps1
@@ -15373,7 +15373,7 @@ THIS SCRIPT MUST NOT BE EDITED AND REDISTRIBUTED WITHOUT EXPRESS PERMISSION OF T
 			$global:BitsProxyOptions = @{
 				'RetryInterval'	      = "60";
 				'RetryTimeout'	      = "180";
-				'ProxyList'		      = $global:ProxyServer;
+				'ProxyList'		      = ($global:ProxyServer | Select-Object -ExpandProperty Address);
 				'ProxyAuthentication' = "Negotiate";
 				'ProxyCredential'	  = $global:ProxyCredentials;
 				'ProxyUsage'		  = "Override";

--- a/Content/DriverAutomationTool.ps1
+++ b/Content/DriverAutomationTool.ps1
@@ -848,7 +848,7 @@ function Show-MainForm_psf
 		$SelectionTabs.SelectedTab = $LogTab
 		global:Write-LogEntry -Value "Info: Validating all required selections have been made" -Severity 1
 		if ($UseProxyServerCheckbox.Checked -eq $true) {
-			Validate-ProxyAccess -ProxyServer $ProxyServerInput.Text -UserName $ProxyUserInput.Text -Password $ProxyPswdInput.Text -URL $URL
+			Validate-ProxyAccess -ProxyServer $ProxyServerInput.Text -UserName $ProxyUserInput.Text -Password $ProxyPswdInput.Text -URL "https://www.scconfigmgr.com"
 		}
 		Validate-Settings
 		if ($global:Validation -eq $true) {


### PR DESCRIPTION
1) For the StartDownloadButton_Click event, the URL used to validate the proxy was $URL which was not assigned any value during my tests. I used the same value used in the "Find-AvailableModels" function to fix this.

2) The BITS option ProxyList requires an object of type Uri but the script currently assigns the proxy object instead. So I used the property 'Address' of the proxy object which is a Uri.

Thank you.