### PR TITLE
Update HP BIOS model XML logic

### DIFF
--- a/Content/DriverAutomationTool.ps1
+++ b/Content/DriverAutomationTool.ps1
@@ -12698,7 +12698,7 @@ THIS SCRIPT MUST NOT BE EDITED AND REDISTRIBUTED WITHOUT EXPRESS PERMISSION OF T
 						global:Write-LogEntry -Value "Info: Reading model XML $HPXMLFile" -Severity 1
 						[xml]$HPSoftPaqDetails = Get-Content -Path $global:TempDirectory\$HPXMLFile
 						$HPBIOSDetails = ($HPSoftPaqDetails.ImagePal.Solutions.UpdateInfo | Where-Object {
-								($_.Category -eq "BIOS") -and ($_.Name -notmatch "Utilities")
+								($_.Category -match "BIOS") -and ($_.Name -notmatch "Utilities")
 							} | Sort-Object Version | Select-Object -First 1)
 						global:Write-LogEntry -Value "Info: BIOS download URL is $($HPBIOSDetails.URL)" -Severity 1
 						Return $HPBIOSDetails


### PR DESCRIPTION
Fixes an issue where the 'category' in the HP model XML didn't equate to "BIOS". Ex: HP ProBook 450 G7