### PR TITLE
Protection against bad data in Model field

### DIFF
--- a/Content/DriverAutomationTool.ps1
+++ b/Content/DriverAutomationTool.ps1
@@ -11849,7 +11849,7 @@ THIS SCRIPT MUST NOT BE EDITED AND REDISTRIBUTED WITHOUT EXPRESS PERMISSION OF T
 			if ($QueryKnownModels -eq $true) {
 				if (-not ([string]::IsNullOrEmpty($SiteServer))) {
 					$HPKnownModels = ($HPKnownModels = Get-WmiObject -ComputerName $SiteServer -Namespace "root\SMS\site_$SiteCode" -Class SMS_G_System_COMPUTER_SYSTEM | Select-Object -Property Manufacturer, Model | Where-Object {
-							(($_.Manufacturer -match "HP") -or ($_.Manufacturer -match "Hewlett-Packard")) -and ($_.Model -notmatch "Proliant")
+							(($_.Manufacturer -match "HP") -or ($_.Manufacturer -match "Hewlett-Packard")) -and ($_.Model -notmatch "Proliant") -and ($_.Model.Trim() -ne "") 
 						}).Model | Sort-Object | Get-Unique -AsString
 				}
 				# Add model to ArrayList if not present


### PR DESCRIPTION
Added trim of model and not equal to BLANK otherwise if a blank model exists in the configmgr instance it selects all models.
Only applied to HP at this point.