### PR TITLE
Update DriverAutomationTool.ps1

### DIFF
--- a/Content/DriverAutomationTool.ps1
+++ b/Content/DriverAutomationTool.ps1
@@ -14582,26 +14582,20 @@ AABJRU5ErkJgggs='))
 							$DellSingleSKU = $global:SkuValue | Select-Object -First 1
 							$global:SkuValue = [string]($global:SkuValue -join ";")
 							global:Write-LogEntry -Value "Info: Using SKU : $DellSingleSKU" -Severity 1
-							$ModelURL = $DellDownloadBase + "/" + ($global:DellModelCabFiles | Where-Object {
-									((($_.SupportedOperatingSystems).OperatingSystem).osCode -match $WindowsVersion) -and ($_.SupportedSystems.Brand.Model.SystemID -match $DellSingleSKU)
-								}).delta
-							$DriverDownload = $DellDownloadBase + "/" + ($global:DellModelCabFiles | Where-Object {
-									((($_.SupportedOperatingSystems).OperatingSystem).osCode -match $WindowsVersion) -and ($_.SupportedSystems.Brand.Model.SystemID -match $DellSingleSKU)
-								}).path
-							$DriverCab = (($global:DellModelCabFiles | Where-Object {
-										((($_.SupportedOperatingSystems).OperatingSystem).osCode -match $WindowsVersion) -and ($_.SupportedSystems.Brand.Model.SystemID -match $DellSingleSKU)
-									}).path).Split("/") | Select-Object -Last 1
+							$temp = ($global:DellModelCabFiles | Where-Object {
+								((($_.SupportedOperatingSystems).OperatingSystem).osCode -match $WindowsVersion) -and ($_.SupportedSystems.Brand.Model.SystemID -match $DellSingleSKU)
+							}) | Sort-Object -Property DateTime | Select-Object -Last 1
+							$ModelURL = $DellDownloadBase + "/" + $temp.delta
+							$DriverDownload = $DellDownloadBase + "/" + $temp.path
+							$DriverCab = $($temp.path).Split("/") | Select-Object -Last 1
 							
 						} else {
-							$ModelURL = $DellDownloadBase + "/" + ($global:DellModelCabFiles | Where-Object {
-									((($_.SupportedOperatingSystems).OperatingSystem).osCode -match $WindowsVersion) -and ($_.SupportedSystems.Brand.Model.SystemID -match $global:SkuValue)
-								}).delta
-							$DriverDownload = $DellDownloadBase + "/" + ($global:DellModelCabFiles | Where-Object {
-									((($_.SupportedOperatingSystems).OperatingSystem).osCode -match $WindowsVersion) -and ($_.SupportedSystems.Brand.Model.SystemID -match $global:SkuValue)
-								}).path
-							$DriverCab = (($global:DellModelCabFiles | Where-Object {
-										((($_.SupportedOperatingSystems).OperatingSystem).osCode -match $WindowsVersion) -and ($_.SupportedSystems.Brand.Model.SystemID -match $global:SkuValue)
-									}).path).Split("/") | Select-Object -Last 1
+							$temp = ($global:DellModelCabFiles | Where-Object {
+								((($_.SupportedOperatingSystems).OperatingSystem).osCode -match $WindowsVersion) -and ($_.SupportedSystems.Brand.Model.SystemID -match $global:SkuValue)
+							}) | Sort-Object -Property DateTime | Select-Object -Last 1
+							$ModelURL = $temp.delta
+							$DriverDownload = $DellDownloadBase + "/" + $temp.path
+							$DriverCab = $($temp.path).Split("/") | Select-Object -Last 1
 						}
 						
 						$ModelURL = $ModelURL.Replace("\", "/")
@@ -15725,7 +15719,6 @@ AABJRU5ErkJgggs='))
 			global:Write-LogEntry -Value "======== Validation Error(s) ========" -Severity 3
 			global:Write-LogEntry -Value "$($ValidationErrors) validation errors have occurred. Please review the log located at $global:LogFilePath." -Severity 3
 		}
-	}
 	
 	# Used to create scheduled task jobs
 	function Schedule-Downloads {


### PR DESCRIPTION
#162 
#160 
#145 
#138 
#122 

Fixed issue where Dell models with more than one version of of the cab file would cause the download to fail.  This was due to the path for all of the cab files for that model and OS being added to the download path.

Example:
ConfigMgr: Downloading from URL: https://downloads.dell.com/FOLDER06414474M/1/3550-win10-A02-08G4V.CAB FOLDER06607260M/1/3550-win10-A03-DJGM7.CAB