### PR TITLE
Updated newly included .gitignore to exclude wildcards in Temp and Logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 Driver Automation Tool/Settings/SelectedModels.json
-Driver Automation Tool/Temp/DATBiosCatalog.json
-Driver Automation Tool/Logs/DriverAutomationTool.log
+Driver Automation Tool/Temp/*
+Driver Automation Tool/Logs/*


### PR DESCRIPTION
Dated log files aren't getting excluded with newly uploaded gitignore. My local copy was excluding itself, Settings\\\*, Temp\\\* and Logs\\\*. Figured Logs and Temp are still safe to wildcard but I can see potential for needing to commit something other than SelectedModels.json to Settings.