### PR TITLE
Replace all ddMMyyyy with yyyyMMdd

### DIFF
--- a/Driver Automation Tool/Modules/DriverAutomationToolCore/DriverAutomationToolCore.psm1
+++ b/Driver Automation Tool/Modules/DriverAutomationToolCore/DriverAutomationToolCore.psm1
@@ -651,7 +651,7 @@ function Get-DATOEMModelInfo {
                             Baseboards = $(if ($sysIds) { $sysIds -join "," } else { "" })
                             OS         = $WindowsVersion
                             'OS Build' = $WindowsBuild
-                            Version    = (Get-Date -Format 'ddMMyyyy')
+                            Version    = (Get-Date -Format 'yyyyMMdd')
                         }
                     }
                 } catch {
@@ -803,7 +803,7 @@ function Get-DATOEMModelInfo {
                             Baseboards = $Model
                             OS         = $WindowsVersion
                             'OS Build' = $WindowsBuild
-                            Version    = (Get-Date -Format 'ddMMyyyy')
+                            Version    = (Get-Date -Format 'yyyyMMdd')
                         }
                     }
                 } catch {
@@ -3002,7 +3002,7 @@ function Start-DATModelProcessing {
                         # Update cached app list so subsequent iterations detect this package
                         if ($null -ne $intuneResult -and -not [string]::IsNullOrEmpty($intuneResult.AppId) -and -not $intuneResult.Skipped) {
                             $driverDisplayName = "$driverNamePrefix - $oem $modelName - $windowsVersion $windowsBuild $arch"
-                            $driverCacheVersion = if (-not [string]::IsNullOrEmpty($catalogDriverVersion)) { $catalogDriverVersion } else { Get-Date -Format "ddMMyyyy" }
+                            $driverCacheVersion = if (-not [string]::IsNullOrEmpty($catalogDriverVersion)) { $catalogDriverVersion } else { Get-Date -Format "yyyyMMdd" }
                             $cachedIntuneApps += [PSCustomObject]@{
                                 id             = $intuneResult.AppId
                                 displayName    = $driverDisplayName
@@ -3086,7 +3086,7 @@ function Start-DATModelProcessing {
                             Write-DATLogEntry -Value "-- Site code: $SiteCode" -Severity 1
                             Set-DATRegistryValue -Name "RunningMessage" -Value "Creating ConfigMgr driver package: $oem $modelName..." -Type String
 
-                            $version = if (-not [string]::IsNullOrEmpty($catalogVersion)) { "$catalogVersion" } else { Get-Date -Format "ddMMyyyy" }
+                            $version = if (-not [string]::IsNullOrEmpty($catalogVersion)) { "$catalogVersion" } else { Get-Date -Format "yyyyMMdd" }
                             $cmParams = @{
                                 DriverPackage = $wimPath
                                 OEM           = $oem
@@ -3338,7 +3338,7 @@ function Start-DATModelProcessing {
                                     $processedBiosModels["$oem|$modelName"] = $biosIntuneResult.AppId
                                     if (-not $biosIntuneResult.Skipped) {
                                         $biosDisplayName = "$biosNamePrefix - $oem $modelName - $arch"
-                                        $biosCacheVersion = if (-not [string]::IsNullOrEmpty($biosEntry.Version)) { $biosEntry.Version } else { Get-Date -Format "ddMMyyyy" }
+                                        $biosCacheVersion = if (-not [string]::IsNullOrEmpty($biosEntry.Version)) { $biosEntry.Version } else { Get-Date -Format "yyyyMMdd" }
                                         $cachedIntuneApps += [PSCustomObject]@{
                                             id             = $biosIntuneResult.AppId
                                             displayName    = $biosDisplayName
@@ -7547,7 +7547,7 @@ function New-DATIntuneRequirementScript {
         - Device manufacturer matches the OEM
         - WMI SystemSKU or Baseboard Product matches one of the model's values
         - OS matches the target OS (Drivers only -- BIOS packages are OS-agnostic)
-        - Package version is newer than any previously installed version (ddMMyyyy comparison)
+        - Package version is newer than any previously installed version (yyyyMMdd comparison)
     #>
     [CmdletBinding()]
     param (
@@ -7614,7 +7614,7 @@ function New-DATIntuneRequirementScript {
 "@
     } elseif ($UpdateType -eq 'BIOS') {
         # BIOS without a catalog release date -- registry exact-match only
-        # (ddMMyyyy parsing is not valid for OEM BIOS version strings like M43KT32A)
+        # (yyyyMMdd parsing is not valid for OEM BIOS version strings like M43KT32A)
         @"
     # Check 4: BIOS version check - registry exact match
     `$regPath = "HKLM:\SOFTWARE\DriverAutomationTool\$regSubKey\$OEM\$Model"
@@ -8562,7 +8562,7 @@ function Invoke-DATIntunePackageCreation {
 
     # Use the supplied version (e.g. BIOS catalog version) if available, otherwise fall back to date
     if ([string]::IsNullOrEmpty($Version)) {
-        $version = Get-Date -Format "ddMMyyyy"
+        $version = Get-Date -Format "yyyyMMdd"
     } else {
         $version = $Version
     }

--- a/Driver Automation Tool/Modules/DriverAutomationToolCore/Templates/Install-BIOS.ps1
+++ b/Driver Automation Tool/Modules/DriverAutomationToolCore/Templates/Install-BIOS.ps1
@@ -257,7 +257,7 @@ function Compare-BIOSVersion {
                         return $true
                     }
                 } else {
-                    # Available version is a DAT package date stamp (ddMMyyyy) -- cannot compare
+                    # Available version is a DAT package date stamp (yyyyMMdd) -- cannot compare
                     Write-CMTraceLog "Dell: Package version '$AvailableBIOSVersion' is not a BIOS version -- skipping comparison, proceeding with update" -Severity 2
                     return $true
                 }

--- a/Driver Automation Tool/UI/MainApplication.ps1
+++ b/Driver Automation Tool/UI/MainApplication.ps1
@@ -6067,7 +6067,7 @@ $btn_RefreshModels.Add_Click({
                                     Baseboards = $Model.SystemId
                                     OS         = $WindowsVersion
                                     'OS Build' = $WindowsBuild
-                                    Version    = (Get-Date -Format 'ddMMyyyy')
+                                    Version    = (Get-Date -Format 'yyyyMMdd')
                                 }
                             }
                         }
@@ -6321,7 +6321,7 @@ $btn_RefreshModels.Add_Click({
                                     Baseboards = $Model
                                     OS         = $WindowsVersion
                                     'OS Build' = $WindowsBuild
-                                    Version    = (Get-Date -Format 'ddMMyyyy')
+                                    Version    = (Get-Date -Format 'yyyyMMdd')
                                 }
                             }
                         }
@@ -12805,7 +12805,7 @@ $btn_CustomBuild.Add_Click({
         }
     })
 
-    $customVersion = Get-Date -Format "ddMMyyyy"
+    $customVersion = Get-Date -Format "yyyyMMdd"
     [void]$script:CustomBuildPS.AddArgument((Resolve-Path $modulePath).Path)
     [void]$script:CustomBuildPS.AddArgument($make)
     [void]$script:CustomBuildPS.AddArgument($model)


### PR DESCRIPTION
A carte blanch replace all ddMMyyyy with yyyyMMdd. Not sure if there's any instances where ddMMyyyy is actually required but I suspect at least of portion of these, if not all, are likely oversights. Also don't wanna live in a world where ddMMyyyy is even considered reasonable for coding. dd/MM/yyyy is fine for feedback but ddMMyyyy make little sense in environments that have the possibility to sort on it.