### PR TITLE
Fix: preserve line breaks in generated toast notification XAML body text

### DIFF
--- a/Driver Automation Tool/Modules/DriverAutomationToolCore/DriverAutomationToolCore.psm1
+++ b/Driver Automation Tool/Modules/DriverAutomationToolCore/DriverAutomationToolCore.psm1
@@ -7090,6 +7090,11 @@ function New-DATIntuneToastScript {
     $greetingPrefix = if (-not [string]::IsNullOrEmpty($CustomToastGreeting)) { $CustomToastGreeting } else { 'Hi' }
     $subtitle = if (-not [string]::IsNullOrEmpty($CustomToastSubtitle)) { $CustomToastSubtitle } else { 'Driver Automation Tool V10' }
 
+    # XML-safe body for embedding in XAML Text attributes.
+    # Using element content collapses newlines via XAML whitespace normalization; the Text
+    # attribute with &#x0a; character references preserves line breaks at parse time.
+    $bodyXamlSafe = $body -replace '&','&amp;' -replace '<','&lt;' -replace '>','&gt;' -replace '"','&quot;' -replace "`r`n",'&#x0a;' -replace "`r",'&#x0a;' -replace "`n",'&#x0a;'
+
     # Read module version from manifest for embedding in generated scripts
     $moduleManifest = Import-PowerShellDataFile -Path (Join-Path $PSScriptRoot 'DriverAutomationToolCore.psd1') -ErrorAction SilentlyContinue
     $scriptVersion = if ($moduleManifest.ModuleVersion) { $moduleManifest.ModuleVersion } else { 'Unknown' }
@@ -7283,7 +7288,7 @@ try {
                            TextAlignment="Center" TextWrapping="Wrap" Margin="0,0,0,10"/>
                 <TextBlock TextWrapping="Wrap" FontSize="13" Foreground="#CBD5E1"
                            HorizontalAlignment="Center" TextAlignment="Center"
-                           LineHeight="20">$body</TextBlock>
+                           LineHeight="20" Text="$bodyXamlSafe"/>
             </StackPanel>
 "@
         $statusCloseButton = @'
@@ -7442,7 +7447,7 @@ try {
                 <TextBlock Text="$heading" FontSize="20" FontWeight="Bold"
                            Foreground="#F8FAFC" Margin="0,0,0,10"/>
                 <TextBlock TextWrapping="Wrap" FontSize="13" Foreground="#CBD5E1"
-                           LineHeight="20">$body</TextBlock>
+                           LineHeight="20" Text="$bodyXamlSafe"/>
             </StackPanel>
 "@
 


### PR DESCRIPTION
## Summary

- Multi-paragraph body text entered in the DAT toast customisation UI displayed correctly in the in-app preview but rendered as a single merged paragraph on the endpoint device.
- Root cause: `New-DATIntuneToastScript` embedded `$body` as **XAML element content** (`<TextBlock>…$body…</TextBlock>`). XAML whitespace normalisation collapses newlines to a single space in element content. The preview window builds WPF objects entirely in code (`$bodyTb.Text = $body`), which preserves `\n` characters — explaining the preview/endpoint discrepancy.
- Fix: compute `$bodyXamlSafe` (XML-escaped body with `\r\n`/`\r`/`\n` → `&#x0a;`) and switch both the update-toast (`$bodyXaml`) and status-toast (`$statusXamlDynamic`) `TextBlock` elements from element content to `Text="$bodyXamlSafe"` attributes. The XAML parser preserves `&#x0a;` character references in attribute values, so `TextBlock.Text` receives the newline characters and WPF renders paragraph breaks as intended.

## Changes

| File | Change |
|------|--------|
| `Modules/DriverAutomationToolCore/DriverAutomationToolCore.psm1` | Added `$bodyXamlSafe` computation; updated two `TextBlock` XAML definitions to use `Text` attribute with XML-safe body string |

## Test plan

- [ ] Enter multi-paragraph body text (two or more lines separated by Enter) in the BIOS Update toast customisation fields
- [ ] Confirm the in-app preview (inline mockup + "Show Preview" button) still shows the paragraph break
- [ ] Build the BIOS update package via Driver Automation Tool and deploy to a test endpoint
- [ ] Confirm the toast on the endpoint now shows the paragraph break matching the preview
- [ ] Repeat for Driver Update, Driver Issues, and BIOS Issues toast types with multi-paragraph body text
- [ ] Confirm single-paragraph body text is unaffected on both preview and endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)